### PR TITLE
[refactor] 1:1 팀원 매칭 개선

### DIFF
--- a/src/main/java/com/example/demo/src/match/MatchProvider.java
+++ b/src/main/java/com/example/demo/src/match/MatchProvider.java
@@ -79,15 +79,6 @@ public class MatchProvider {
         }
     }
 
-    public DiscXy getUserDiscXy(int userIdx) throws BaseException {
-        try {
-            DiscXy discXy = matchDao.getUserDiscXy(userIdx);
-            return discXy;
-        } catch (Exception exception){
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
-
     public List<GetUserMatchRes> getUserMatches(int userIdx) throws BaseException {
         try {
             // 1 : 연령대
@@ -138,7 +129,7 @@ public class MatchProvider {
                 }
             }
 
-            List<GetUserMatchRes> getUserMatchRes = matchDao.getUserMatches(userIdx, getUserDiscXy(userIdx)
+            List<GetUserMatchRes> getUserMatchRes = matchDao.getUserMatches(userIdx
                     , getAgeRangeFilter, getRegionFilter, getOccupationFilter, getInterestsFilter);
             return getUserMatchRes;
         } catch (Exception exception){

--- a/src/main/java/com/example/demo/src/match/model/SearchDiscXy.java
+++ b/src/main/java/com/example/demo/src/match/model/SearchDiscXy.java
@@ -1,0 +1,12 @@
+package com.example.demo.src.match.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+public class SearchDiscXy {
+    private double x;
+    private double y;
+}


### PR DESCRIPTION
**유저가 누른 좋아요의 개수가 5명 미만인 경우,**
- 유저가 설정한 팀원 필터링 기반으로 필터링
- 차단하거나 신고한 유저 추천에서 제외
- 이전에 이미 좋아요나 넘기기를 누른 유저 제외

**유저가 누른 좋아요의 개수가 5명 이상인 경우,**
- 유저 행위 데이터(좋아요)를 기준으로 유저가 찾는 팀원의 업무 성향인 Search Disc 좌표 값을 조정
- 업무 성향의 일치 퍼센트가 높은 유저를 먼저 추천